### PR TITLE
Apply README styling guidelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "14.2.3",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "lucide-react": "^0.370.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,10 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
-html, body {
+html,
+body {
   height: 100%;
 }
 
-body {
-  font-family: 'Inter', sans-serif;
+@layer base {
+  body {
+    @apply bg-background text-text font-sans;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,9 @@
 import './globals.css';
 import { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
 import Layout from '../components/Layout';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const metadata = {
   title: 'UrgentPsychCRM',
@@ -9,8 +12,8 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      <body className="bg-gray-50 text-gray-900">
+    <html lang="en" className={inter.variable}>
+      <body>
         <Layout>{children}</Layout>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 export default function Home() {
   return (
     <main className="p-6">
-      <h1 className="text-3xl font-bold">UrgentPsychCRM</h1>
+      <h1 className="text-3xl font-bold text-accent">UrgentPsychCRM</h1>
       <p className="mt-4 text-gray-600">Welcome to the CRM!</p>
     </main>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen">
       <Sidebar />
-      <main className="flex-1 p-6 bg-gray-50">{children}</main>
+      <main className="flex-1 p-6 bg-background">{children}</main>
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,13 +1,21 @@
 import Link from 'next/link';
 import { useState } from 'react';
+import {
+  Home,
+  Folder,
+  Users,
+  Calendar,
+  DollarSign,
+  Settings as SettingsIcon,
+} from 'lucide-react';
 
 const links = [
-  { href: '/', label: 'Dashboard' },
-  { href: '/matters', label: 'Matters' },
-  { href: '/patients', label: 'Patients' },
-  { href: '/calendar', label: 'Calendar' },
-  { href: '/billing', label: 'Billing' },
-  { href: '/settings', label: 'Settings' },
+  { href: '/', label: 'Dashboard', icon: Home },
+  { href: '/matters', label: 'Matters', icon: Folder },
+  { href: '/patients', label: 'Patients', icon: Users },
+  { href: '/calendar', label: 'Calendar', icon: Calendar },
+  { href: '/billing', label: 'Billing', icon: DollarSign },
+  { href: '/settings', label: 'Settings', icon: SettingsIcon },
 ];
 
 export default function Sidebar() {
@@ -15,7 +23,7 @@ export default function Sidebar() {
   return (
     <aside className={`h-full bg-white shadow-md ${open ? 'w-56' : 'w-20'} transition-all`}>
       <button
-        className="p-4 focus:outline-none"
+        className="p-4 focus:outline-none text-accent"
         onClick={() => setOpen(!open)}
         aria-label="Toggle sidebar"
       >
@@ -25,8 +33,12 @@ export default function Sidebar() {
         <ul className="space-y-2">
           {links.map((link) => (
             <li key={link.href}>
-              <Link href={link.href} className="block px-4 py-2 hover:bg-gray-100 rounded">
-                {link.label}
+              <Link
+                href={link.href}
+                className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 rounded"
+              >
+                <link.icon className="h-5 w-5 text-accent" />
+                {open && <span>{link.label}</span>}
               </Link>
             </li>
           ))}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,16 @@ import type { Config } from 'tailwindcss';
 const config: Config = {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: '#F9FAFB',
+        text: '#1A1A1A',
+        accent: '#4F46E5',
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)', 'Inter', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- implement README UI style colors and fonts in Tailwind config
- load Inter font in the root layout
- apply global background and text classes
- add lucide-react icons to sidebar navigation
- tweak home page heading with accent color

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*