### PR TITLE
Add dashboard cards and improved sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,25 @@
+import DashboardCard from '../components/DashboardCard';
+
+const cards = [
+  { href: '/matters', title: 'Matters', description: 'Manage active matters' },
+  { href: '/patients', title: 'Patients', description: 'View patient directory' },
+  { href: '/calendar', title: 'Calendar', description: 'Schedule and events' },
+  { href: '/billing', title: 'Billing', description: 'Track time and invoices' },
+  { href: '/documents', title: 'Documents', description: 'Organize files' },
+  { href: '/referrals', title: 'Referrals', description: 'Manage referrals' },
+  { href: '/resources', title: 'Resources', description: 'Community resources' },
+  { href: '/settings', title: 'Settings', description: 'Configure application' },
+];
+
 export default function Home() {
   return (
     <main className="p-6">
-      <h1 className="text-3xl font-bold">UrgentPsychCRM</h1>
-      <p className="mt-4 text-gray-600">Welcome to the CRM!</p>
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+      <div className="mt-6 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {cards.map((card) => (
+          <DashboardCard key={card.href} {...card} />
+        ))}
+      </div>
     </main>
   );
 }

--- a/src/components/DashboardCard.tsx
+++ b/src/components/DashboardCard.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+interface DashboardCardProps {
+  title: string;
+  description?: string;
+  href?: string;
+}
+
+export default function DashboardCard({ title, description, href }: DashboardCardProps) {
+  const content = (
+    <div className="p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow">
+      <h3 className="text-lg font-semibold">{title}</h3>
+      {description && <p className="mt-2 text-sm text-gray-600">{description}</p>}
+    </div>
+  );
+  if (href) {
+    return (
+      <Link href={href} className="block focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded-lg">
+        {content}
+      </Link>
+    );
+  }
+  return content;
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { useState } from 'react';
+import { usePathname } from 'next/navigation';
 
 const links = [
   { href: '/', label: 'Dashboard' },
@@ -12,6 +13,7 @@ const links = [
 
 export default function Sidebar() {
   const [open, setOpen] = useState(true);
+  const pathname = usePathname();
   return (
     <aside className={`h-full bg-white shadow-md ${open ? 'w-56' : 'w-20'} transition-all`}>
       <button
@@ -23,13 +25,19 @@ export default function Sidebar() {
       </button>
       <nav className="mt-4">
         <ul className="space-y-2">
-          {links.map((link) => (
-            <li key={link.href}>
-              <Link href={link.href} className="block px-4 py-2 hover:bg-gray-100 rounded">
-                {link.label}
-              </Link>
-            </li>
-          ))}
+          {links.map((link) => {
+            const active = pathname === link.href;
+            return (
+              <li key={link.href}>
+                <Link
+                  href={link.href}
+                  className={`block px-4 py-2 rounded hover:bg-gray-100 ${active ? 'bg-gray-100 font-medium' : ''}`}
+                >
+                  {link.label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
- add `DashboardCard` component
- create a modular dashboard with cards linking to pages
- highlight the active link in the sidebar

## Testing
- `npm install` *(fails: npm could not run without package-lock)*
- `npm run lint` *(fails: `next` not found)*