### PR TITLE
Implement matters list and detail pages

### DIFF
--- a/src/app/matters/[id]/page.tsx
+++ b/src/app/matters/[id]/page.tsx
@@ -1,11 +1,61 @@
+'use client';
+import { useState } from 'react';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { getMatter } from '@/data/sampleMatters';
+
 interface Params {
   params: { id: string };
 }
 
 export default function MatterDetail({ params }: Params) {
+  const matter = getMatter(params.id);
+  const [tab, setTab] = useState<'details' | 'notes'>('details');
+
+  if (!matter) return notFound();
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold">Matter {params.id}</h1>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">{matter.title}</h1>
+      <div className="flex space-x-4 border-b">
+        <button
+          onClick={() => setTab('details')}
+          className={`py-2 px-1${
+            tab === 'details' ? ' border-b-2 border-accent font-medium' : ''
+          }`}
+        >
+          Details
+        </button>
+        <button
+          onClick={() => setTab('notes')}
+          className={`py-2 px-1${
+            tab === 'notes' ? ' border-b-2 border-accent font-medium' : ''
+          }`}
+        >
+          Notes
+        </button>
+      </div>
+      {tab === 'details' ? (
+        <div className="space-y-2">
+          <div>
+            <strong>Patient:</strong> {matter.patient}
+          </div>
+          <div>
+            <strong>Status:</strong> {matter.status}
+          </div>
+          <div>
+            <strong>Created:</strong> {matter.created}
+          </div>
+          <p className="pt-4">{matter.description}</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="italic text-gray-500">No notes yet.</p>
+        </div>
+      )}
+      <Link href="/matters" className="text-accent hover:underline">
+        Back to list
+      </Link>
     </div>
   );
 }

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -1,7 +1,66 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+import { sampleMatters, Matter } from '@/data/sampleMatters';
+
 export default function MattersPage() {
+  const [query, setQuery] = useState('');
+
+  const filtered = sampleMatters.filter(
+    (m) =>
+      m.title.toLowerCase().includes(query.toLowerCase()) ||
+      m.patient.toLowerCase().includes(query.toLowerCase())
+  );
+
   return (
-    <div>
+    <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Matters</h1>
+      <div>
+        <input
+          type="text"
+          placeholder="Filter matters..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full md:w-64 p-2 border rounded shadow-inner"
+        />
+      </div>
+      <div className="bg-white rounded shadow overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">
+                Matter
+              </th>
+              <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">
+                Patient
+              </th>
+              <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">
+                Status
+              </th>
+              <th className="px-4 py-2 text-left text-sm font-semibold text-gray-700">
+                Created
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {filtered.map((m: Matter) => (
+              <tr key={m.id} className="hover:bg-gray-50">
+                <td className="px-4 py-2">
+                  <Link
+                    href={`/matters/${m.id}`}
+                    className="text-accent hover:underline"
+                  >
+                    {m.title}
+                  </Link>
+                </td>
+                <td className="px-4 py-2">{m.patient}</td>
+                <td className="px-4 py-2">{m.status}</td>
+                <td className="px-4 py-2">{m.created}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/data/sampleMatters.ts
+++ b/src/data/sampleMatters.ts
@@ -1,0 +1,39 @@
+export interface Matter {
+  id: string;
+  title: string;
+  patient: string;
+  status: 'Open' | 'Closed' | 'Archived';
+  created: string;
+  description: string;
+}
+
+export const sampleMatters: Matter[] = [
+  {
+    id: '1',
+    title: 'Medication Adjustment',
+    patient: 'John Doe',
+    status: 'Open',
+    created: '2024-06-10',
+    description: 'Review medication plan and adjust dosage as needed.'
+  },
+  {
+    id: '2',
+    title: 'Intake Consultation',
+    patient: 'Jane Smith',
+    status: 'Closed',
+    created: '2024-05-22',
+    description: 'Initial patient intake and assessment completed.'
+  },
+  {
+    id: '3',
+    title: 'Follow Up',
+    patient: 'Alex Johnson',
+    status: 'Open',
+    created: '2024-05-30',
+    description: 'Schedule follow up for therapy progress review.'
+  }
+];
+
+export function getMatter(id: string): Matter | undefined {
+  return sampleMatters.find((m) => m.id === id);
+}


### PR DESCRIPTION
## Summary
- add sample matter data
- implement a filterable matters list view
- implement matter detail view with basic tabs

## Testing
- `npm run lint` *(fails: next not found)*