### PR TITLE
Add patient portal layout

### DIFF
--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,7 +1,41 @@
+import PatientInfo from '@components/portal/PatientInfo';
+import Timeline, { TimelineEvent } from '@components/portal/Timeline';
+
+const patientFields = [
+  { label: 'Name', value: 'John Doe' },
+  { label: 'Date of Birth', value: '1980-05-15', type: 'date' },
+  { label: 'Email', value: 'john@example.com' },
+  { label: 'Phone', value: '(555) 123-4567' },
+  { label: 'Address', value: '123 Main St, Springfield' },
+  { label: 'Insurance', value: 'Acme Health' },
+];
+
+const timeline: TimelineEvent[] = [
+  {
+    date: '2024-05-01',
+    title: 'Initial Consultation',
+    note: 'Discussed treatment goals and medication history.',
+  },
+  {
+    date: '2024-05-15',
+    title: 'Follow-up Appointment',
+    note: 'Patient reports improved mood and sleep.',
+  },
+  {
+    date: '2024-06-01',
+    title: 'Medication Adjustment',
+    note: 'Increased dosage of prescribed medication.',
+  },
+];
+
 export default function PatientPortalPage() {
   return (
-    <div>
-      <h1 className="text-2xl font-semibold">Patient Portal (Read Only)</h1>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Patient Portal</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <PatientInfo fields={patientFields} />
+        <Timeline events={timeline} />
+      </div>
     </div>
   );
 }

--- a/src/components/portal/PatientInfo.tsx
+++ b/src/components/portal/PatientInfo.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface Field {
+  label: string;
+  value: string;
+  type?: string;
+}
+
+function ReadonlyField({ label, value, type = 'text' }: Field) {
+  return (
+    <div>
+      <label className="text-sm text-gray-600">{label}</label>
+      <input
+        type={type}
+        value={value}
+        disabled
+        className="mt-1 w-full rounded border-gray-200 bg-gray-100 p-2"
+      />
+    </div>
+  );
+}
+
+export interface PatientInfoProps {
+  fields: Field[];
+}
+
+export default function PatientInfo({ fields }: PatientInfoProps) {
+  return (
+    <div className="bg-white p-6 rounded shadow space-y-4">
+      <h2 className="text-lg font-medium">Patient Information</h2>
+      <div className="space-y-4">
+        {fields.map((f) => (
+          <ReadonlyField key={f.label} {...f} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/portal/Timeline.tsx
+++ b/src/components/portal/Timeline.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface TimelineEvent {
+  date: string;
+  title: string;
+  note?: string;
+}
+
+export interface TimelineProps {
+  events: TimelineEvent[];
+}
+
+function TimelineItem({ event }: { event: TimelineEvent }) {
+  return (
+    <div className="relative pl-8 pb-8 last:pb-0">
+      <div className="absolute left-0 top-2 h-3 w-3 rounded-full bg-accent"></div>
+      <div className="bg-white p-4 rounded shadow">
+        <div className="text-sm text-gray-500">{event.date}</div>
+        <div className="font-medium">{event.title}</div>
+        {event.note && <div className="text-sm text-gray-600 mt-1">{event.note}</div>}
+      </div>
+    </div>
+  );
+}
+
+export default function Timeline({ events }: TimelineProps) {
+  return (
+    <div className="bg-white p-6 rounded shadow">
+      <h2 className="text-lg font-medium mb-4">Timeline</h2>
+      <div className="relative">
+        <div className="absolute left-1.5 top-0 bottom-0 w-px bg-gray-200" />
+        {events.map((e, idx) => (
+          <TimelineItem key={idx} event={e} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement read-only patient portal with patient info and timeline cards
- create `PatientInfo` and `Timeline` components for layout

## Testing
- `npm run lint` *(fails: next not found)*