### PR TITLE
Add tabbed matter detail layout

### DIFF
--- a/src/app/matters/[id]/page.tsx
+++ b/src/app/matters/[id]/page.tsx
@@ -10,52 +10,76 @@ interface Params {
 
 export default function MatterDetail({ params }: Params) {
   const matter = getMatter(params.id);
-  const [tab, setTab] = useState<'details' | 'notes'>('details');
+  const [tab, setTab] = useState<'overview' | 'documents' | 'billing'>('overview');
 
   if (!matter) return notFound();
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">{matter.title}</h1>
-      <div className="flex space-x-4 border-b">
-        <button
-          onClick={() => setTab('details')}
-          className={`py-2 px-1${
-            tab === 'details' ? ' border-b-2 border-accent font-medium' : ''
-          }`}
-        >
-          Details
-        </button>
-        <button
-          onClick={() => setTab('notes')}
-          className={`py-2 px-1${
-            tab === 'notes' ? ' border-b-2 border-accent font-medium' : ''
-          }`}
-        >
-          Notes
-        </button>
-      </div>
-      {tab === 'details' ? (
-        <div className="space-y-2">
-          <div>
-            <strong>Patient:</strong> {matter.patient}
-          </div>
-          <div>
-            <strong>Status:</strong> {matter.status}
-          </div>
-          <div>
-            <strong>Created:</strong> {matter.created}
-          </div>
-          <p className="pt-4">{matter.description}</p>
+    <div className="flex flex-col md:flex-row h-full gap-6">
+      {/* Left summary sidebar */}
+      <aside className="md:w-64 shrink-0 space-y-4 bg-white rounded shadow p-4 overflow-y-auto">
+        <h1 className="text-xl font-semibold">{matter.title}</h1>
+        <div>
+          <strong>Patient:</strong> {matter.patient}
         </div>
-      ) : (
-        <div className="space-y-2">
-          <p className="italic text-gray-500">No notes yet.</p>
+        <div>
+          <strong>Status:</strong> {matter.status}
         </div>
-      )}
-      <Link href="/matters" className="text-accent hover:underline">
-        Back to list
-      </Link>
+        <div>
+          <strong>Created:</strong> {matter.created}
+        </div>
+        <p className="pt-2">{matter.description}</p>
+        <Link href="/matters" className="text-accent hover:underline block">
+          Back to list
+        </Link>
+      </aside>
+
+      {/* Right tabbed content */}
+      <section className="flex-1 flex flex-col">
+        <div className="flex space-x-4 border-b mb-4">
+          <button
+            onClick={() => setTab('overview')}
+            className={`py-2 px-1${tab === 'overview' ? ' border-b-2 border-accent font-medium' : ''}`}
+          >
+            Overview
+          </button>
+          <button
+            onClick={() => setTab('documents')}
+            className={`py-2 px-1${tab === 'documents' ? ' border-b-2 border-accent font-medium' : ''}`}
+          >
+            Documents
+          </button>
+          <button
+            onClick={() => setTab('billing')}
+            className={`py-2 px-1${tab === 'billing' ? ' border-b-2 border-accent font-medium' : ''}`}
+          >
+            Billing
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto space-y-4">
+          {tab === 'overview' && (
+            <details open className="bg-white rounded shadow p-4">
+              <summary className="cursor-pointer font-medium">Overview</summary>
+              <p className="mt-2 italic text-gray-500">No additional information.</p>
+            </details>
+          )}
+
+          {tab === 'documents' && (
+            <details open className="bg-white rounded shadow p-4">
+              <summary className="cursor-pointer font-medium">Documents</summary>
+              <p className="mt-2 italic text-gray-500">No documents yet.</p>
+            </details>
+          )}
+
+          {tab === 'billing' && (
+            <details open className="bg-white rounded shadow p-4">
+              <summary className="cursor-pointer font-medium">Billing</summary>
+              <p className="mt-2 italic text-gray-500">No billing info yet.</p>
+            </details>
+          )}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- split matter detail view into summary sidebar and right tabs
- add collapsible tab sections for overview, documents, and billing

## Testing
- `npm install` *(fails: next not found or network unavailable)*
- `npm run lint` *(fails: next not found)*