### PR TITLE
Add resources downloads to patient portal

### DIFF
--- a/src/app/portal/page.tsx
+++ b/src/app/portal/page.tsx
@@ -1,5 +1,6 @@
 import PatientInfo from '@components/portal/PatientInfo';
 import Timeline, { TimelineEvent } from '@components/portal/Timeline';
+import Downloads, { DownloadFile } from '@components/portal/Downloads';
 
 const patientFields = [
   { label: 'Name', value: 'John Doe' },
@@ -28,6 +29,12 @@ const timeline: TimelineEvent[] = [
   },
 ];
 
+const resources: DownloadFile[] = [
+  { id: 1, name: 'Treatment Plan.pdf', progress: 100 },
+  { id: 2, name: 'Medication Guide.pdf', progress: 60 },
+  { id: 3, name: 'Exercise Tips.pdf', progress: 20 },
+];
+
 export default function PatientPortalPage() {
   return (
     <div className="space-y-6">
@@ -36,6 +43,7 @@ export default function PatientPortalPage() {
         <PatientInfo fields={patientFields} />
         <Timeline events={timeline} />
       </div>
+      <Downloads files={resources} />
     </div>
   );
 }

--- a/src/components/portal/Downloads.tsx
+++ b/src/components/portal/Downloads.tsx
@@ -1,0 +1,49 @@
+import { FileText, CheckCircle } from 'lucide-react';
+
+export interface DownloadFile {
+  id: number;
+  name: string;
+  progress: number; // percentage 0-100
+}
+
+function DownloadItem({ file }: { file: DownloadFile }) {
+  const complete = file.progress >= 100;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        {complete ? (
+          <CheckCircle className="h-4 w-4 text-green-600" />
+        ) : (
+          <FileText className="h-4 w-4 text-accent" />
+        )}
+        <span className="text-sm font-medium">{file.name}</span>
+        <span className="ml-auto text-sm text-gray-500">
+          {complete ? 'Ready' : `${file.progress}%`}
+        </span>
+      </div>
+      <div className="h-2 bg-gray-200 rounded">
+        <div
+          className="h-full rounded bg-accent transition-all"
+          style={{ width: `${Math.min(file.progress, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export interface DownloadsProps {
+  files: DownloadFile[];
+}
+
+export default function Downloads({ files }: DownloadsProps) {
+  return (
+    <div className="bg-white p-6 rounded shadow">
+      <h2 className="text-lg font-medium mb-4">Resources</h2>
+      <div className="space-y-4">
+        {files.map((file) => (
+          <DownloadItem key={file.id} file={file} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Downloads` component with status bars for files
- display the new resources list on the patient portal page

## Testing
- `npm run lint` *(fails: `next: not found`)*