### PR TITLE
Fix server component mismatch errors

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Timer from '@components/billing/Timer';
 import InvoiceCard, { Invoice } from '@components/billing/InvoiceCard';
 import { useState } from 'react';

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import {
   ChevronLeft,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { useState } from 'react';
 import {

--- a/src/components/billing/InvoiceCard.tsx
+++ b/src/components/billing/InvoiceCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 export interface Invoice {
   id: number;
   patient: string;

--- a/src/components/billing/Timer.tsx
+++ b/src/components/billing/Timer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useEffect } from 'react';
 
 export default function Timer() {


### PR DESCRIPTION
## Summary
- mark Sidebar as a client component
- mark Calendar component as a client component
- mark billing InvoiceCard and Timer components as client components
- mark billing page as a client component

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*