### PR TITLE
Add page load animations

### DIFF
--- a/src/components/AnimatedMain.tsx
+++ b/src/components/AnimatedMain.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function AnimatedMain({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <main key={pathname} className="flex-1 p-6 bg-background animate-fade-in">
+      {children}
+    </main>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import Sidebar from './Sidebar';
+import AnimatedMain from './AnimatedMain';
 
 interface LayoutProps {
   children: ReactNode;
@@ -17,7 +18,7 @@ export default function Layout({ children, title }: LayoutProps) {
       </header>
       <div className="flex flex-1">
         <Sidebar />
-        <main className="flex-1 p-6 bg-background">{children}</main>
+        <AnimatedMain>{children}</AnimatedMain>
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,15 @@ const config: Config = {
       fontFamily: {
         sans: ['var(--font-inter)', 'Inter', 'sans-serif'],
       },
+      keyframes: {
+        'fade-in': {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+      },
+      animation: {
+        'fade-in': 'fade-in 0.3s ease-in',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add global fade-in animation to Tailwind config
- wrap pages in `AnimatedMain` for simple transitions

## Testing
- `npm run lint`
