### PR TITLE
Add folder management in documents page

### DIFF
--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -20,6 +20,7 @@ const initialFolders: Folder[] = [
 export default function DocumentsPage() {
   const [documents, setDocuments] = useState<DocumentFile[]>(initialDocs);
   const [folders, setFolders] = useState<Folder[]>(initialFolders);
+  const [newFolderName, setNewFolderName] = useState('');
   const [dragId, setDragId] = useState<number | null>(null);
 
   const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,6 +36,24 @@ export default function DocumentsPage() {
   };
 
   const handleDragStart = (id: number) => setDragId(id);
+
+  const createFolder = () => {
+    const name = newFolderName.trim();
+    if (name === '') return;
+    const newFolder: Folder = { id: Date.now(), name, docs: [] };
+    setFolders((prev) => [...prev, newFolder]);
+    setNewFolderName('');
+  };
+
+  const deleteFolder = (id: number) => {
+    setFolders((fs) => {
+      const folder = fs.find((f) => f.id === id);
+      if (folder) {
+        setDocuments((docs) => [...docs, ...folder.docs]);
+      }
+      return fs.filter((f) => f.id !== id);
+    });
+  };
 
   const handleDrop = (folderId: number) => {
     if (dragId === null) return;
@@ -74,12 +93,29 @@ export default function DocumentsPage() {
         </div>
         <div>
           <h2 className="font-medium mb-2">Folders</h2>
+          <div className="flex gap-2 mb-4">
+            <input
+              type="text"
+              value={newFolderName}
+              onChange={(e) => setNewFolderName(e.target.value)}
+              placeholder="New folder name"
+              className="flex-1 p-2 border rounded"
+            />
+            <button
+              type="button"
+              onClick={createFolder}
+              className="px-3 py-2 rounded bg-accent text-white hover:bg-indigo-700"
+            >
+              Add
+            </button>
+          </div>
           <div className="space-y-4">
             {folders.map((folder) => (
               <FolderCard
                 key={folder.id}
                 folder={folder}
                 onDrop={handleDrop}
+                onDelete={deleteFolder}
               />
             ))}
           </div>

--- a/src/components/documents/FolderCard.tsx
+++ b/src/components/documents/FolderCard.tsx
@@ -1,4 +1,4 @@
-import { Folder as FolderIcon } from 'lucide-react';
+import { Folder as FolderIcon, Trash } from 'lucide-react';
 import { DocumentFile } from './DocumentItem';
 
 export interface Folder {
@@ -10,9 +10,11 @@ export interface Folder {
 export default function FolderCard({
   folder,
   onDrop,
+  onDelete,
 }: {
   folder: Folder;
   onDrop: (folderId: number) => void;
+  onDelete?: (folderId: number) => void;
 }) {
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -29,7 +31,18 @@ export default function FolderCard({
           <FolderIcon className="h-5 w-5 text-accent" />
           <span className="font-medium">{folder.name}</span>
         </div>
-        <span className="text-sm text-gray-500">{folder.docs.length} docs</span>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-500">{folder.docs.length} docs</span>
+          {onDelete && (
+            <button
+              onClick={() => onDelete(folder.id)}
+              aria-label="Delete folder"
+              className="p-1 rounded hover:bg-red-100"
+            >
+              <Trash className="h-4 w-4 text-red-600" />
+            </button>
+          )}
+        </div>
       </div>
       {folder.docs.length > 0 && (
         <ul className="text-sm space-y-1">


### PR DESCRIPTION
## Summary
- allow creating folders from Documents page
- support deleting folders and moving items back to the document list
- add delete button to `FolderCard`

## Testing
- `npm run lint`
- `npm run build` *(fails: connect EHOSTUNREACH to fonts.googleapis.com)*