### PR TITLE
Add editable calendar and dynamic billing

### DIFF
--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -4,7 +4,7 @@ import Timer from '@components/billing/Timer';
 import InvoiceCard, { Invoice } from '@components/billing/InvoiceCard';
 import { useState } from 'react';
 
-const invoices: Invoice[] = [
+const initialInvoices: Invoice[] = [
   { id: 1, patient: 'John Doe', amount: '$200', status: 'Pending', dueDate: '2024-06-01' },
   { id: 2, patient: 'Jane Smith', amount: '$150', status: 'Paid', dueDate: '2024-05-15' },
   { id: 3, patient: 'Alex Johnson', amount: '$300', status: 'Overdue', dueDate: '2024-04-20' },
@@ -12,14 +12,43 @@ const invoices: Invoice[] = [
 
 export default function BillingPage() {
   const [rate, setRate] = useState('200');
-  const [hours, setHours] = useState(1);
+  const [entries, setEntries] = useState<number[]>([]);
+  const [invoices, setInvoices] = useState<Invoice[]>(initialInvoices);
+
+  const handleStop = (secs: number) => {
+    if (secs > 0) setEntries([...entries, secs]);
+  };
+
+  const totalHours = entries.reduce((t, s) => t + s / 3600, 0);
+
+  const format = (s: number) => {
+    const hrs = Math.floor(s / 3600);
+    const mins = Math.floor((s % 3600) / 60);
+    const secs = s % 60;
+    return `${hrs.toString().padStart(2, '0')}:${mins
+      .toString()
+      .padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const generateInvoice = () => {
+    const amount = `$${(totalHours * parseInt(rate)).toFixed(2)}`;
+    const newInv: Invoice = {
+      id: invoices.length + 1,
+      patient: 'New Session',
+      amount,
+      status: 'Pending',
+      dueDate: new Date().toISOString().slice(0, 10),
+    };
+    setInvoices([newInv, ...invoices]);
+    setEntries([]);
+  };
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Time Tracking / Billing</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="space-y-4">
-          <Timer />
+          <Timer onStop={handleStop} />
           <div className="p-6 bg-white rounded shadow space-y-4">
             <div>
               <label className="block text-sm font-medium mb-1" htmlFor="rate">
@@ -36,22 +65,22 @@ export default function BillingPage() {
                 <option value="250">$250/hr</option>
               </select>
             </div>
-            <div>
-              <label className="block text-sm font-medium mb-1" htmlFor="hours">
-                Hours
-              </label>
-              <input
-                id="hours"
-                type="range"
-                min="0"
-                max="8"
-                step="0.25"
-                value={hours}
-                onChange={(e) => setHours(parseFloat(e.target.value))}
-                className="w-full"
-              />
-              <div className="text-sm text-right mt-1">{hours}h</div>
+            <div className="text-sm">
+              {entries.map((e, i) => (
+                <div key={i} className="flex justify-between">
+                  <span>Entry {i + 1}</span>
+                  <span>{format(e)}</span>
+                </div>
+              ))}
+              <div className="font-medium mt-2">Total: {totalHours.toFixed(2)}h</div>
             </div>
+            <button
+              onClick={generateInvoice}
+              disabled={entries.length === 0}
+              className="w-full px-4 py-2 rounded bg-accent text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              Generate Invoice
+            </button>
           </div>
         </div>
         <div className="space-y-4">

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,5 +1,7 @@
+"use client";
 import Calendar from '@components/Calendar';
 import { CalendarEvent } from '@components/Calendar';
+import { useState, useEffect } from 'react';
 
 const sampleEvents: CalendarEvent[] = [
   {
@@ -22,11 +24,96 @@ const sampleEvents: CalendarEvent[] = [
   },
 ];
 
+const emptyEvent: CalendarEvent = { date: '', title: '', type: 'default', details: '' };
+
 export default function CalendarPage() {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [form, setForm] = useState<CalendarEvent>(emptyEvent);
+  const [editing, setEditing] = useState<number | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('calendarEvents');
+    if (stored) setEvents(JSON.parse(stored));
+    else setEvents(sampleEvents);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('calendarEvents', JSON.stringify(events));
+  }, [events]);
+
+  const saveEvent = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.date || !form.title) return;
+    if (editing !== null) {
+      setEvents(events.map((ev, idx) => (idx === editing ? form : ev)));
+    } else {
+      setEvents([...events, form]);
+    }
+    setForm(emptyEvent);
+    setEditing(null);
+  };
+
+  const handleEdit = (ev: CalendarEvent, idx: number) => {
+    setForm(ev);
+    setEditing(idx);
+  };
+
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Calendar</h1>
-      <Calendar events={sampleEvents} />
+      <Calendar events={events} onEventEdit={handleEdit} />
+      <form onSubmit={saveEvent} className="p-4 bg-white rounded shadow space-y-2">
+        <div className="flex gap-2">
+          <input
+            type="date"
+            value={form.date}
+            onChange={(e) => setForm({ ...form, date: e.target.value })}
+            className="p-2 border rounded w-36"
+            required
+          />
+          <input
+            type="text"
+            placeholder="Title"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            className="flex-1 p-2 border rounded"
+            required
+          />
+          <select
+            value={form.type}
+            onChange={(e) => setForm({ ...form, type: e.target.value as CalendarEvent['type'] })}
+            className="p-2 border rounded"
+          >
+            <option value="default">Other</option>
+            <option value="appointment">Appointment</option>
+            <option value="task">Task</option>
+          </select>
+        </div>
+        <textarea
+          placeholder="Details"
+          value={form.details}
+          onChange={(e) => setForm({ ...form, details: e.target.value })}
+          className="w-full p-2 border rounded"
+          rows={2}
+        />
+        <div className="flex gap-2">
+          <button type="submit" className="px-4 py-2 rounded bg-accent text-white hover:bg-indigo-700">
+            {editing !== null ? 'Save' : 'Add'}
+          </button>
+          {editing !== null && (
+            <button
+              type="button"
+              onClick={() => {
+                setForm(emptyEvent);
+                setEditing(null);
+              }}
+              className="px-4 py-2 rounded bg-gray-200 hover:bg-gray-300"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -16,6 +16,7 @@ export interface CalendarEvent {
 interface CalendarProps {
   initialDate?: Date;
   events?: CalendarEvent[];
+  onEventEdit?: (ev: CalendarEvent, index: number) => void;
 }
 
 function startOfMonth(date: Date) {
@@ -57,15 +58,15 @@ function getMonthDays(date: Date) {
   return days;
 }
 
-export default function Calendar({ initialDate = new Date(), events = [] }: CalendarProps) {
+export default function Calendar({ initialDate = new Date(), events = [], onEventEdit }: CalendarProps) {
   const [current, setCurrent] = useState(startOfMonth(initialDate));
   const [weekStart, setWeekStart] = useState(startOfWeek(initialDate));
   const [expanded, setExpanded] = useState<string | null>(null);
   const days = getMonthDays(current);
 
-  const eventsMap = events.reduce<Record<string, CalendarEvent[]>>((acc, ev) => {
+  const eventsMap = events.reduce<Record<string, { event: CalendarEvent; index: number }[]>>((acc, ev, idx) => {
     if (!acc[ev.date]) acc[ev.date] = [];
-    acc[ev.date].push(ev);
+    acc[ev.date].push({ event: ev, index: idx });
     return acc;
   }, {});
 
@@ -150,8 +151,8 @@ export default function Calendar({ initialDate = new Date(), events = [] }: Cale
             >
               <div className="self-end text-xs font-medium">{day.getDate()}</div>
               <div className="space-y-0.5 overflow-hidden">
-                {dayEvents.map((ev, idx) => {
-                  const id = `${ev.date}-${idx}`;
+                {dayEvents.map(({ event: ev, index }) => {
+                  const id = `${ev.date}-${index}`;
                   return (
                     <div key={id} className="space-y-1">
                       <button
@@ -164,9 +165,17 @@ export default function Calendar({ initialDate = new Date(), events = [] }: Cale
                       >
                         {ev.title}
                       </button>
-                      {expanded === id && ev.details && (
-                        <div className="text-gray-700 text-[10px] bg-gray-100 p-1 rounded">
-                          {ev.details}
+                      {expanded === id && (
+                        <div className="text-gray-700 text-[10px] bg-gray-100 p-1 rounded space-y-1">
+                          {ev.details && <div>{ev.details}</div>}
+                          {onEventEdit && (
+                            <button
+                              onClick={() => onEventEdit(ev, index)}
+                              className="px-1 py-0.5 text-[10px] rounded bg-accent text-white"
+                            >
+                              Edit
+                            </button>
+                          )}
                         </div>
                       )}
                     </div>

--- a/src/components/billing/Timer.tsx
+++ b/src/components/billing/Timer.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from 'react';
 
-export default function Timer() {
+interface TimerProps {
+  onStop?: (seconds: number) => void;
+}
+export default function Timer({ onStop }: TimerProps) {
   const [seconds, setSeconds] = useState(0);
   const [running, setRunning] = useState(false);
 
@@ -12,7 +15,15 @@ export default function Timer() {
     return () => clearInterval(id);
   }, [running]);
 
-  const toggle = () => setRunning(!running);
+  const toggle = () => {
+    if (running) {
+      setRunning(false);
+      onStop?.(seconds);
+      setSeconds(0);
+    } else {
+      setRunning(true);
+    }
+  };
   const reset = () => {
     setSeconds(0);
     setRunning(false);


### PR DESCRIPTION
## Summary
- make calendar events editable
- persist calendar events in localStorage with form for add/edit
- allow timer to send tracked time up to the billing page
- show tracked time entries and generate invoices from them

## Testing
- `npm run lint`
