### PR TITLE
Integrate Prisma SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 coverage
 .env
 .DS_Store
+prisma/dev.db

--- a/README.md
+++ b/README.md
@@ -47,3 +47,23 @@ Simpler read-only design with locked fields, visual timelines, and downloadable 
 Settings Page
 Design with grouped sections, clean toggles, permission badges, and minimal icon usage. Consistent padding and form field hierarchy.
 
+## Development
+
+This project uses Prisma with a local SQLite database.
+
+### Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the initial migration to create the database and Prisma client:
+
+   ```bash
+   npx prisma migrate dev --name init
+   ```
+
+The SQLite file is located in `prisma/dev.db` and is ignored from git.
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
+};

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "test": "jest"
   },
   "dependencies": {
     "lucide-react": "^0.370.0",
     "next": "^14.2.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@prisma/client": "^5.10.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
@@ -20,6 +22,10 @@
     "eslint-config-next": "^14.2.3",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "prisma": "^5.10.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "supertest": "^6.3.4"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,40 @@
+// Prisma schema
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Patient {
+  id        Int            @id @default(autoincrement())
+  name      String
+  email     String
+  phone     String
+  avatar    String
+  status    String
+  lastVisit DateTime
+  timeline  TimelineEvent[]
+  matters   Matter[]
+}
+
+model TimelineEvent {
+  id        Int      @id @default(autoincrement())
+  date      DateTime
+  description String
+  patient   Patient @relation(fields: [patientId], references: [id])
+  patientId Int
+}
+
+model Matter {
+  id          Int      @id @default(autoincrement())
+  title       String
+  patient     Patient  @relation(fields: [patientId], references: [id])
+  patientId   Int
+  status      String
+  created     DateTime
+  description String
+}

--- a/src/app/api/matters/[id]/route.ts
+++ b/src/app/api/matters/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+interface Params { params: { id: string } }
+
+export async function GET(_req: Request, { params }: Params) {
+  const id = Number(params.id);
+  const matter = await prisma.matter.findUnique({ where: { id }, include: { patient: true } });
+  if (!matter) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(matter);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  const id = Number(params.id);
+  const data = await req.json();
+  const matter = await prisma.matter.update({ where: { id }, data });
+  return NextResponse.json(matter);
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const id = Number(params.id);
+  await prisma.matter.delete({ where: { id } });
+  return NextResponse.json({});
+}

--- a/src/app/api/matters/route.ts
+++ b/src/app/api/matters/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET() {
+  const matters = await prisma.matter.findMany({ include: { patient: true } });
+  return NextResponse.json(matters);
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const matter = await prisma.matter.create({ data });
+  return NextResponse.json(matter, { status: 201 });
+}

--- a/src/app/api/patients/[id]/route.ts
+++ b/src/app/api/patients/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+interface Params { params: { id: string } }
+
+export async function GET(_req: Request, { params }: Params) {
+  const id = Number(params.id);
+  const patient = await prisma.patient.findUnique({ where: { id }, include: { timeline: true } });
+  if (!patient) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(patient);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  const id = Number(params.id);
+  const data = await req.json();
+  const patient = await prisma.patient.update({ where: { id }, data });
+  return NextResponse.json(patient);
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const id = Number(params.id);
+  await prisma.patient.delete({ where: { id } });
+  return NextResponse.json({});
+}

--- a/src/app/api/patients/route.ts
+++ b/src/app/api/patients/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET() {
+  const patients = await prisma.patient.findMany({ include: { timeline: true } });
+  return NextResponse.json(patients);
+}
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const patient = await prisma.patient.create({ data });
+  return NextResponse.json(patient, { status: 201 });
+}

--- a/src/app/matters/[id]/page.tsx
+++ b/src/app/matters/[id]/page.tsx
@@ -1,18 +1,22 @@
 'use client';
-import { useState } from 'react';
-import { notFound } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { getMatter } from '@/data/sampleMatters';
 
 interface Params {
   params: { id: string };
 }
 
 export default function MatterDetail({ params }: Params) {
-  const matter = getMatter(params.id);
+  const [matter, setMatter] = useState<any | null>(null);
   const [tab, setTab] = useState<'overview' | 'documents' | 'billing'>('overview');
 
-  if (!matter) return notFound();
+  useEffect(() => {
+    fetch(`/api/matters/${params.id}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setMatter(data));
+  }, [params.id]);
+
+  if (!matter) return <p>Loading...</p>;
 
   return (
     <div className="flex flex-col md:flex-row h-full gap-6">
@@ -20,7 +24,7 @@ export default function MatterDetail({ params }: Params) {
       <aside className="md:w-64 shrink-0 space-y-4 bg-white rounded shadow p-4 overflow-y-auto">
         <h1 className="text-xl font-semibold">{matter.title}</h1>
         <div>
-          <strong>Patient:</strong> {matter.patient}
+          <strong>Patient:</strong> {matter.patient?.name}
         </div>
         <div>
           <strong>Status:</strong> {matter.status}

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -1,14 +1,29 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { sampleMatters, Matter } from '@/data/sampleMatters';
+
+interface Matter {
+  id: number;
+  title: string;
+  patientId: number;
+  patient: { name: string } | null;
+  status: string;
+  created: string;
+  description: string;
+}
 
 export default function MattersPage() {
   const [query, setQuery] = useState('');
-  const [matters, setMatters] = useState<Matter[]>(sampleMatters);
+  const [matters, setMatters] = useState<Matter[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
   const [sortKey, setSortKey] = useState<keyof Matter>('created');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  useEffect(() => {
+    fetch('/api/matters')
+      .then((res) => res.json())
+      .then((data) => setMatters(data));
+  }, []);
 
   const toggleSort = (key: keyof Matter) => {
     if (sortKey === key) {
@@ -23,7 +38,7 @@ export default function MattersPage() {
     .filter(
       (m) =>
         m.title.toLowerCase().includes(query.toLowerCase()) ||
-        m.patient.toLowerCase().includes(query.toLowerCase())
+        (m.patient?.name.toLowerCase() ?? '').includes(query.toLowerCase())
     )
     .sort((a, b) => {
       const valA = a[sortKey];
@@ -145,7 +160,7 @@ export default function MattersPage() {
                     {m.title}
                   </Link>
                 </td>
-                <td className="px-4 py-2">{m.patient}</td>
+                <td className="px-4 py-2">{m.patient?.name}</td>
                 <td className="px-4 py-2">{m.status}</td>
                 <td className="px-4 py-2">{m.created}</td>
               </tr>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
-import patients from '@/data/patients';
-import { sampleMatters } from '@/data/sampleMatters';
+import prisma from '@/lib/prisma';
 
 const appointments = [
   { id: 1, patient: 'John Doe', time: 'Jun 14, 10:00 AM' },
@@ -7,9 +6,9 @@ const appointments = [
   { id: 3, patient: 'Alex Johnson', time: 'Jun 18, 9:30 AM' },
 ];
 
-export default function Home() {
-  const newPatients = patients.slice(0, 3);
-  const recentMatters = sampleMatters.slice(0, 3);
+export default async function Home() {
+  const newPatients = await prisma.patient.findMany({ take: 3, orderBy: { id: 'desc' } });
+  const recentMatters = await prisma.matter.findMany({ take: 3, orderBy: { id: 'desc' } });
 
   return (
     <div className="space-y-6">

--- a/src/app/patients/[id]/page.tsx
+++ b/src/app/patients/[id]/page.tsx
@@ -1,12 +1,15 @@
 import { notFound } from 'next/navigation';
-import patients from '@/data/patients';
+import prisma from '@/lib/prisma';
 
 interface Params {
   params: { id: string };
 }
 
-export default function PatientProfile({ params }: Params) {
-  const patient = patients.find((p) => p.id === Number(params.id));
+export default async function PatientProfile({ params }: Params) {
+  const patient = await prisma.patient.findUnique({
+    where: { id: Number(params.id) },
+    include: { timeline: true },
+  });
 
   if (!patient) {
     notFound();

--- a/src/app/patients/page.tsx
+++ b/src/app/patients/page.tsx
@@ -1,13 +1,29 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import patients from '@/data/patients';
+
+interface Patient {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  avatar: string;
+  status: string;
+  lastVisit: string;
+}
 
 export default function PatientsPage() {
   const [query, setQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [afterFilter, setAfterFilter] = useState('');
+  const [patients, setPatients] = useState<Patient[]>([]);
+
+  useEffect(() => {
+    fetch('/api/patients')
+      .then((res) => res.json())
+      .then((data) => setPatients(data));
+  }, []);
 
   const filtered = patients.filter((p) =>
     p.name.toLowerCase().includes(query.toLowerCase()) &&

--- a/src/app/referrals/page.tsx
+++ b/src/app/referrals/page.tsx
@@ -1,7 +1,11 @@
 'use client';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FolderPlus, Upload } from 'lucide-react';
-import patients from '@/data/patients';
+
+interface Patient {
+  id: number;
+  name: string;
+}
 
 interface Template {
   id: number;
@@ -23,6 +27,13 @@ export default function ReferralsPage() {
   const [nextId, setNextId] = useState(3);
   const [patientQuery, setPatientQuery] = useState('');
   const [selectedPatientId, setSelectedPatientId] = useState<number | null>(null);
+  const [patients, setPatients] = useState<Patient[]>([]);
+
+  useEffect(() => {
+    fetch('/api/patients')
+      .then((res) => res.json())
+      .then((data) => setPatients(data));
+  }, []);
 
   const addFolder = () => {
     if (!folderName.trim()) return;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['query'],
+  });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,0 +1,6 @@
+import prisma from '../src/lib/prisma';
+
+test('prisma connects', async () => {
+  const patients = await prisma.patient.findMany();
+  expect(Array.isArray(patients)).toBe(true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@app/*": ["app/*"]
     }
   },
-  "include": ["next-env.d.ts", "src/**/*"],
+  "include": ["next-env.d.ts", "src/**/*", "tests/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add Prisma client and CLI packages
- define SQLite schema for Patient, Matter, and TimelineEvent
- implement Prisma client helper
- expose REST API routes for patients and matters
- refactor pages to fetch data from the API
- add Jest config and a simple database test
- ignore generated SQLite DB
- document Prisma setup in README

## Testing
- `npm install` *(fails: no network access)*
- `npm test` *(fails: jest not found)*