### PR TITLE
Integrate Prisma and create API routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 coverage
 .env
 .DS_Store
+prisma/dev.db

--- a/README.md
+++ b/README.md
@@ -47,3 +47,14 @@ Simpler read-only design with locked fields, visual timelines, and downloadable 
 Settings Page
 Design with grouped sections, clean toggles, permission badges, and minimal icon usage. Consistent padding and form field hierarchy.
 
+
+## Database Setup
+
+This project uses Prisma with a local SQLite database. To initialize the database and run migrations:
+
+```bash
+npm install
+npx prisma migrate dev --name init
+```
+
+The generated SQLite database is stored in `prisma/dev.db` which is ignored from version control.

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "test": "node --test"
   },
   "dependencies": {
     "lucide-react": "^0.370.0",
     "next": "^14.2.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@prisma/client": "^5.14.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
@@ -20,6 +22,7 @@
     "eslint-config-next": "^14.2.3",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "prisma": "^5.14.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,52 @@
+// Prisma schema
+// datasource and generator
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+// Models
+model Patient {
+  id        Int            @id @default(autoincrement())
+  name      String
+  email     String         @unique
+  phone     String
+  avatar    String?
+  status    PatientStatus  @default(Active)
+  lastVisit DateTime
+  matters   Matter[]
+  events    TimelineEvent[]
+}
+
+model TimelineEvent {
+  id          Int      @id @default(autoincrement())
+  date        DateTime
+  description String
+  patient     Patient  @relation(fields: [patientId], references: [id])
+  patientId   Int
+}
+
+model Matter {
+  id        Int           @id @default(autoincrement())
+  title     String
+  patient   Patient       @relation(fields: [patientId], references: [id])
+  patientId Int
+  status    MatterStatus  @default(Open)
+  created   DateTime      @default(now())
+  description String
+}
+
+enum PatientStatus {
+  Active
+  Inactive
+}
+
+enum MatterStatus {
+  Open
+  Closed
+  Archived
+}

--- a/src/app/matters/[id]/page.tsx
+++ b/src/app/matters/[id]/page.tsx
@@ -1,18 +1,35 @@
 'use client';
 import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { getMatter } from '@/data/sampleMatters';
 
 interface Params {
   params: { id: string };
 }
 
+interface Matter {
+  id: number;
+  title: string;
+  patient: string;
+  status: 'Open' | 'Closed' | 'Archived';
+  created: string;
+  description: string;
+}
+
 export default function MatterDetail({ params }: Params) {
-  const matter = getMatter(params.id);
+  const [matter, setMatter] = useState<Matter | null>(null);
   const [tab, setTab] = useState<'overview' | 'documents' | 'billing'>('overview');
 
-  if (!matter) return notFound();
+  useEffect(() => {
+    fetch(`/api/matters/${params.id}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data) return notFound();
+        setMatter(data);
+      });
+  }, [params.id]);
+  if (!matter) return null;
 
   return (
     <div className="flex flex-col md:flex-row h-full gap-6">

--- a/src/app/matters/new/page.tsx
+++ b/src/app/matters/new/page.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import patients from '@/data/patients';
+
+interface Patient {
+  id: number;
+  name: string;
+}
 
 interface FormState {
   title: string;
@@ -14,6 +18,7 @@ interface FormState {
 
 export default function NewMatterPage() {
   const router = useRouter();
+  const [patients, setPatients] = useState<Patient[]>([]);
   const [form, setForm] = useState<FormState>({
     title: '',
     patient: '',
@@ -22,6 +27,13 @@ export default function NewMatterPage() {
     description: ''
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    fetch('/api/patients')
+      .then((res) => res.json())
+      .then((data) => setPatients(data))
+      .catch(() => setPatients([]));
+  }, []);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>

--- a/src/app/matters/page.tsx
+++ b/src/app/matters/page.tsx
@@ -1,14 +1,29 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { sampleMatters, Matter } from '@/data/sampleMatters';
+
+interface Matter {
+  id: number;
+  title: string;
+  patient: string;
+  status: 'Open' | 'Closed' | 'Archived';
+  created: string;
+  description: string;
+}
 
 export default function MattersPage() {
   const [query, setQuery] = useState('');
-  const [matters, setMatters] = useState<Matter[]>(sampleMatters);
+  const [matters, setMatters] = useState<Matter[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
   const [sortKey, setSortKey] = useState<keyof Matter>('created');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  useEffect(() => {
+    fetch('/api/matters')
+      .then((res) => res.json())
+      .then((data) => setMatters(data))
+      .catch(() => setMatters([]))
+  }, [])
 
   const toggleSort = (key: keyof Matter) => {
     if (sortKey === key) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,14 @@
-import patients from '@/data/patients';
-import { sampleMatters } from '@/data/sampleMatters';
+interface Patient {
+  id: number;
+  name: string;
+  phone: string;
+}
+
+interface Matter {
+  id: number;
+  title: string;
+  status: string;
+}
 
 const appointments = [
   { id: 1, patient: 'John Doe', time: 'Jun 14, 10:00 AM' },
@@ -7,9 +16,15 @@ const appointments = [
   { id: 3, patient: 'Alex Johnson', time: 'Jun 18, 9:30 AM' },
 ];
 
-export default function Home() {
-  const newPatients = patients.slice(0, 3);
-  const recentMatters = sampleMatters.slice(0, 3);
+export default async function Home() {
+  const [patientsRes, mattersRes] = await Promise.all([
+    fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/patients`, { cache: 'no-store' }),
+    fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/matters`, { cache: 'no-store' })
+  ])
+  const patients: Patient[] = patientsRes.ok ? await patientsRes.json() : []
+  const matters: Matter[] = mattersRes.ok ? await mattersRes.json() : []
+  const newPatients = patients.slice(0, 3)
+  const recentMatters = matters.slice(0, 3)
 
   return (
     <div className="space-y-6">

--- a/src/app/patients/[id]/page.tsx
+++ b/src/app/patients/[id]/page.tsx
@@ -1,35 +1,48 @@
 import { notFound } from 'next/navigation';
-import patients from '@/data/patients';
+
+interface TimelineEvent {
+  date: string;
+  description: string;
+}
+
+interface Patient {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  avatar: string;
+  status: 'Active' | 'Inactive';
+  lastVisit: string;
+  timeline: TimelineEvent[];
+}
 
 interface Params {
   params: { id: string };
 }
 
-export default function PatientProfile({ params }: Params) {
-  const patient = patients.find((p) => p.id === Number(params.id));
-
-  if (!patient) {
-    notFound();
-  }
+export default async function PatientProfile({ params }: Params) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ''}/api/patients/${params.id}`, { cache: 'no-store' })
+  if (!res.ok) notFound()
+  const patient: Patient = await res.json()
 
   return (
     <div className="space-y-6">
       <div className="space-y-4 md:grid md:grid-cols-2 md:gap-4">
         <div className="bg-white rounded-2xl shadow p-6 flex items-center gap-4">
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={patient!.avatar} alt="" className="h-16 w-16 rounded-full" />
+          <img src={patient.avatar} alt="" className="h-16 w-16 rounded-full" />
           <div>
-            <h1 className="text-2xl font-semibold">{patient!.name}</h1>
-            <p className="text-gray-500">{patient!.email}</p>
-            <p className="text-gray-500">{patient!.phone}</p>
-            <p className="text-gray-500">Status: {patient!.status}</p>
-            <p className="text-gray-500">Last visit: {patient!.lastVisit}</p>
+            <h1 className="text-2xl font-semibold">{patient.name}</h1>
+            <p className="text-gray-500">{patient.email}</p>
+            <p className="text-gray-500">{patient.phone}</p>
+            <p className="text-gray-500">Status: {patient.status}</p>
+            <p className="text-gray-500">Last visit: {patient.lastVisit}</p>
           </div>
         </div>
         <div className="bg-white rounded-2xl shadow p-6">
           <h2 className="text-lg font-medium mb-2">Timeline</h2>
           <ul className="space-y-2">
-            {patient!.timeline.map((event, i) => (
+            {patient.timeline.map((event, i) => (
               <li
                 key={i}
                 className="p-4 bg-gray-50 rounded-xl flex justify-between"

--- a/src/app/patients/page.tsx
+++ b/src/app/patients/page.tsx
@@ -1,13 +1,36 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import patients from '@/data/patients';
+
+interface TimelineEvent {
+  date: string;
+  description: string;
+}
+
+interface Patient {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  avatar: string;
+  status: 'Active' | 'Inactive';
+  lastVisit: string;
+  timeline: TimelineEvent[];
+}
 
 export default function PatientsPage() {
+  const [patients, setPatients] = useState<Patient[]>([]);
   const [query, setQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [afterFilter, setAfterFilter] = useState('');
+
+  useEffect(() => {
+    fetch('/api/patients')
+      .then((res) => res.json())
+      .then((data) => setPatients(data))
+      .catch(() => setPatients([]));
+  }, []);
 
   const filtered = patients.filter((p) =>
     p.name.toLowerCase().includes(query.toLowerCase()) &&

--- a/src/app/referrals/page.tsx
+++ b/src/app/referrals/page.tsx
@@ -1,7 +1,11 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FolderPlus, Upload, Eye, Trash2, Pencil } from 'lucide-react';
-import patients from '@/data/patients';
+
+interface Patient {
+  id: number;
+  name: string;
+}
 
 interface Template {
   id: number;
@@ -22,8 +26,16 @@ export default function ReferralsPage() {
   ]);
   const [folderName, setFolderName] = useState('');
   const [nextId, setNextId] = useState(3);
+  const [patients, setPatients] = useState<Patient[]>([]);
   const [patientQuery, setPatientQuery] = useState('');
   const [selectedPatientId, setSelectedPatientId] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetch('/api/patients')
+      .then((res) => res.json())
+      .then((data) => setPatients(data))
+      .catch(() => setPatients([]));
+  }, []);
 
   const addFolder = () => {
     if (!folderName.trim()) return;

--- a/src/pages/api/matters/[id].ts
+++ b/src/pages/api/matters/[id].ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const matter = await prisma.matter.findUnique({ where: { id }, include: { patient: true } })
+    if (!matter) return res.status(404).json({ error: 'Not found' })
+    res.status(200).json(matter)
+  } else if (req.method === 'PUT') {
+    try {
+      const matter = await prisma.matter.update({ where: { id }, data: req.body })
+      res.status(200).json(matter)
+    } catch (err) {
+      res.status(400).json({ error: 'Unable to update matter' })
+    }
+  } else if (req.method === 'DELETE') {
+    try {
+      await prisma.matter.delete({ where: { id } })
+      res.status(204).end()
+    } catch (err) {
+      res.status(400).json({ error: 'Unable to delete matter' })
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'PUT', 'DELETE'])
+    res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+}

--- a/src/pages/api/matters/index.ts
+++ b/src/pages/api/matters/index.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const matters = await prisma.matter.findMany({ include: { patient: true } })
+    res.status(200).json(matters)
+  } else if (req.method === 'POST') {
+    try {
+      const matter = await prisma.matter.create({ data: req.body })
+      res.status(201).json(matter)
+    } catch (err) {
+      res.status(400).json({ error: 'Unable to create matter' })
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST'])
+    res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+}

--- a/src/pages/api/patients/[id].ts
+++ b/src/pages/api/patients/[id].ts
@@ -1,0 +1,31 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = Number(req.query.id)
+
+  if (req.method === 'GET') {
+    const patient = await prisma.patient.findUnique({ where: { id }, include: { events: true, matters: true } })
+    if (!patient) return res.status(404).json({ error: 'Not found' })
+    res.status(200).json(patient)
+  } else if (req.method === 'PUT') {
+    try {
+      const patient = await prisma.patient.update({ where: { id }, data: req.body })
+      res.status(200).json(patient)
+    } catch (err) {
+      res.status(400).json({ error: 'Unable to update patient' })
+    }
+  } else if (req.method === 'DELETE') {
+    try {
+      await prisma.patient.delete({ where: { id } })
+      res.status(204).end()
+    } catch (err) {
+      res.status(400).json({ error: 'Unable to delete patient' })
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'PUT', 'DELETE'])
+    res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+}

--- a/src/pages/api/patients/index.ts
+++ b/src/pages/api/patients/index.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const patients = await prisma.patient.findMany({ include: { events: true } })
+    res.status(200).json(patients)
+  } else if (req.method === 'POST') {
+    const data = req.body
+    try {
+      const patient = await prisma.patient.create({ data })
+      res.status(201).json(patient)
+    } catch (err) {
+      res.status(400).json({ error: 'Unable to create patient' })
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST'])
+    res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+}

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,7 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import handler from '../src/pages/api/patients/index'
+
+ test('patients api exports function', () => {
+   assert.strictEqual(typeof handler, 'function')
+ })

--- a/tests/prisma.test.js
+++ b/tests/prisma.test.js
@@ -1,0 +1,12 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+test('connects to database', async () => {
+  await prisma.$connect()
+  const result = await prisma.$queryRaw`SELECT 1;`
+  assert.ok(result)
+  await prisma.$disconnect()
+})


### PR DESCRIPTION
## Summary
- add Prisma schema for Patient, Matter, and related models
- expose REST endpoints under `src/pages/api`
- refactor pages to fetch data from the new API
- document Prisma setup in README
- ignore generated SQLite file
- add very small test suite

## Testing
- `npm test` *(fails: Cannot find module '@prisma/client')*